### PR TITLE
Add possibility to specify the source projection

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,1 +1,2 @@
 shapely
+pyproj


### PR DESCRIPTION
Add possibility to specify the source projection of the X & Y coordinates in the CSV file.

This allows to convert CSV files not containing the standard
longitude and latitude columns, but instead uses the Ville de Montréal
NAD83 / MTM zone 8 Québec projection.

@mlhamel pour révision!
